### PR TITLE
feat: add only-untranslated option to bulk DeepL translation

### DIFF
--- a/resources/lang/de/filament-deepl-translations.php
+++ b/resources/lang/de/filament-deepl-translations.php
@@ -15,7 +15,11 @@ return [
     'multiple' => [
         'label' => 'Translate with DeepL',
         'modal' => [
-            'heading' => 'Overwrite all translations',
+            'heading' => 'Mit DeepL übersetzen',
+        ],
+        'only_untranslated' => [
+            'label' => 'Nur nicht übersetzte Datensätze übersetzen',
+            'helper' => 'Datensätze, die bereits eine Übersetzung in der Zielsprache haben, werden übersprungen, sodass vorhandene (manuelle) Übersetzungen erhalten bleiben.',
         ],
         'notifications' => [
             'title' => 'Content sent to DeepL and will be processed in the background.',

--- a/resources/lang/en/filament-deepl-translations.php
+++ b/resources/lang/en/filament-deepl-translations.php
@@ -15,7 +15,11 @@ return [
     'multiple' => [
         'label' => 'Translate with DeepL',
         'modal' => [
-            'heading' => 'Overwrite all translations',
+            'heading' => 'Translate with DeepL',
+        ],
+        'only_untranslated' => [
+            'label' => 'Only translate untranslated records',
+            'helper' => 'Records that already have a translation in the target language are skipped, preserving existing (manual) translations.',
         ],
         'notifications' => [
             'title' => 'Content sent to DeepL and will be processed in the background.',

--- a/resources/lang/nl/filament-deepl-translations.php
+++ b/resources/lang/nl/filament-deepl-translations.php
@@ -15,7 +15,11 @@ return [
     'multiple' => [
         'label' => 'Vertalen met DeepL',
         'modal' => [
-            'heading' => 'Overschrijf alle vertalingen',
+            'heading' => 'Vertalen met DeepL',
+        ],
+        'only_untranslated' => [
+            'label' => 'Alleen niet-vertaalde records vertalen',
+            'helper' => 'Records die al een vertaling in de doeltaal hebben, worden overgeslagen zodat bestaande (handmatige) vertalingen behouden blijven.',
         ],
         'notifications' => [
             'title' => 'Content is verzonden naar DeepL en worden in de achtergrond verwerkt.',

--- a/src/Actions/DeeplBulkTranslatableAction.php
+++ b/src/Actions/DeeplBulkTranslatableAction.php
@@ -5,6 +5,7 @@ namespace Concept7\FilamentDeeplTranslations\Actions;
 use Concept7\FilamentDeeplTranslations\Jobs\BatchTranslateJob;
 use Filament\Actions\BulkAction;
 use Filament\Actions\Concerns\CanCustomizeProcess;
+use Filament\Forms\Components\Checkbox;
 use Filament\Forms\Components\Select;
 use Filament\Support\Facades\FilamentIcon;
 use Illuminate\Database\Eloquent\Collection;
@@ -50,12 +51,16 @@ class DeeplBulkTranslatableAction extends BulkAction
                 Select::make('target')
                     ->label(__('filament-deepl-translations::filament-deepl-translations.target'))
                     ->options($langs),
+                Checkbox::make('only_untranslated')
+                    ->label(__('filament-deepl-translations::filament-deepl-translations.multiple.only_untranslated.label'))
+                    ->helperText(__('filament-deepl-translations::filament-deepl-translations.multiple.only_untranslated.helper'))
+                    ->default(true),
             ];
         });
 
         $this->action(function (array $data): void {
             $this->process(function (Collection $records) use ($data): void {
-                BatchTranslateJob::dispatch($records, $data['source'], $data['target']);
+                BatchTranslateJob::dispatch($records, $data['source'], $data['target'], (bool) ($data['only_untranslated'] ?? true));
             });
 
             $this->success();

--- a/src/Actions/DeeplBulkTranslatableAction.php
+++ b/src/Actions/DeeplBulkTranslatableAction.php
@@ -60,7 +60,7 @@ class DeeplBulkTranslatableAction extends BulkAction
 
         $this->action(function (array $data): void {
             $this->process(function (Collection $records) use ($data): void {
-                BatchTranslateJob::dispatch($records, $data['source'], $data['target'], (bool) ($data['only_untranslated'] ?? true));
+                BatchTranslateJob::dispatch($records, $data['source'], $data['target'], (bool) data_get($data, 'only_untranslated', true));
             });
 
             $this->success();

--- a/src/Contracts/Translatable.php
+++ b/src/Contracts/Translatable.php
@@ -15,7 +15,7 @@ interface Translatable
     /**
      * @return string
      */
-    public function getTranslation(string $key, string $locale);
+    public function getTranslation(string $key, string $locale, bool $useFallbackLocale = true);
 
     /**
      * @return static

--- a/src/Jobs/BatchTranslateJob.php
+++ b/src/Jobs/BatchTranslateJob.php
@@ -20,13 +20,14 @@ class BatchTranslateJob implements ShouldQueue
     public function __construct(
         private Collection $records,
         private string $sourceLanguage,
-        private string $targetLanguage
+        private string $targetLanguage,
+        private bool $onlyUntranslated = false
     ) {}
 
     public function handle()
     {
         $this->records->each(function (Model $record) {
-            dispatch(new TranslateJob($record, $this->sourceLanguage, $this->targetLanguage));
+            dispatch(new TranslateJob($record, $this->sourceLanguage, $this->targetLanguage, $this->onlyUntranslated));
         });
     }
 }

--- a/src/Jobs/TranslateJob.php
+++ b/src/Jobs/TranslateJob.php
@@ -27,11 +27,16 @@ class TranslateJob implements ShouldQueue
          */
         private Model $record,
         private string $sourceLanguage,
-        private string $targetLanguage
+        private string $targetLanguage,
+        private bool $onlyUntranslated = false
     ) {}
 
     public function handle()
     {
+        if ($this->onlyUntranslated && $this->hasExistingTranslation()) {
+            return;
+        }
+
         $options = ['app_info' => new AppInfo('filament-deepl-translations', config('filament-deepl-translations.version'))];
         $translator = new DeepLClient(config('services.deepl.api_key'), $options);
 
@@ -60,5 +65,19 @@ class TranslateJob implements ShouldQueue
         $this->record->save();
 
         event(new RecordLanguageUpdatedEvent($this->record, $this->targetLanguage));
+    }
+
+    private function hasExistingTranslation(): bool
+    {
+        /** @var \Illuminate\Database\Eloquent\Model&\Concept7\FilamentDeeplTranslations\Contracts\Translatable&object{translatable: list<string>} $record */
+        $record = $this->record;
+
+        foreach ($record->translatable as $field) {
+            if (filled($record->getTranslation($field, $this->targetLanguage, false))) {
+                return true;
+            }
+        }
+
+        return false;
     }
 }

--- a/tests/Feature/OnlyUntranslatedTest.php
+++ b/tests/Feature/OnlyUntranslatedTest.php
@@ -1,0 +1,39 @@
+<?php
+
+use Concept7\FilamentDeeplTranslations\Events\RecordLanguageUpdatedEvent;
+use Concept7\FilamentDeeplTranslations\Jobs\BatchTranslateJob;
+use Concept7\FilamentDeeplTranslations\Jobs\TranslateJob;
+use Illuminate\Database\Eloquent\Collection;
+use Illuminate\Support\Facades\Bus;
+use Illuminate\Support\Facades\Event;
+use Workbench\App\Models\TranslatableModel;
+
+it('skips a record that already has a target-language translation', function (): void {
+    Event::fake();
+
+    $record = new TranslatableModel;
+    $record->setTranslation('title', 'nl', 'Hallo wereld');
+    $record->setTranslation('title', 'en', 'Hello world');
+
+    (new TranslateJob($record, 'nl', 'en', true))->handle();
+
+    // The guard returns before a DeepLClient is ever constructed, so the record
+    // never reaches DeepL and the existing translation is left untouched.
+    expect($record->getTranslation('title', 'en', false))->toBe('Hello world');
+
+    Event::assertNotDispatched(RecordLanguageUpdatedEvent::class);
+});
+
+it('dispatches a TranslateJob per record when batching only untranslated', function (): void {
+    Bus::fake();
+
+    $records = new Collection([
+        (new TranslatableModel)->setTranslation('title', 'nl', 'Een'),
+        (new TranslatableModel)->setTranslation('title', 'nl', 'Twee'),
+    ]);
+
+    (new BatchTranslateJob($records, 'nl', 'en', true))->handle();
+
+    Bus::assertDispatched(TranslateJob::class);
+    Bus::assertDispatchedTimes(TranslateJob::class, 2);
+});

--- a/workbench/app/Models/TranslatableModel.php
+++ b/workbench/app/Models/TranslatableModel.php
@@ -1,0 +1,60 @@
+<?php
+
+namespace Workbench\App\Models;
+
+use Concept7\FilamentDeeplTranslations\Contracts\Translatable;
+use Illuminate\Database\Eloquent\Model;
+
+/**
+ * Minimal translatable test model.
+ *
+ * Implements the package's Translatable contract with a hand-rolled per-field
+ * locale store (mirroring spatie/laravel-translatable's public API) so the test
+ * suite stays offline and free of a runtime dependency on that package.
+ */
+class TranslatableModel extends Model implements Translatable
+{
+    protected $guarded = [];
+
+    public $timestamps = false;
+
+    /**
+     * @var array<int, string>
+     */
+    public array $translatable = ['title'];
+
+    /**
+     * @var array<string, string>
+     */
+    protected $casts = [
+        'title' => 'array',
+    ];
+
+    public function getTranslation(string $key, string $locale, bool $useFallbackLocale = true): string
+    {
+        $translations = $this->getAttribute($key) ?? [];
+
+        if (array_key_exists($locale, $translations)) {
+            return (string) $translations[$locale];
+        }
+
+        if ($useFallbackLocale) {
+            $fallback = config('app.fallback_locale');
+
+            if (is_string($fallback) && array_key_exists($fallback, $translations)) {
+                return (string) $translations[$fallback];
+            }
+        }
+
+        return '';
+    }
+
+    public function setTranslation(string $key, string $locale, string $value): static
+    {
+        $translations = $this->getAttribute($key) ?? [];
+        $translations[$locale] = $value;
+        $this->setAttribute($key, $translations);
+
+        return $this;
+    }
+}


### PR DESCRIPTION
Adds an **"Only translate untranslated records"** checkbox (default **ON**) to the bulk DeepL translate action. When enabled, any record that already has a translation in the **target** language (in any translatable field) is skipped, preserving existing (manual) translations. When off, the current overwrite behaviour is unchanged.

Implements ClickUp ticket 86cagbwkn.

## Changes
- `Contracts\Translatable::getTranslation` gains an optional `bool $useFallbackLocale = true` param (matches spatie/laravel-translatable's real signature) so a target translation can be read **without** fallback.
- Bulk action (`DeeplBulkTranslatableAction`): new `only_untranslated` checkbox (default ON); the flag is passed through `BatchTranslateJob` → `TranslateJob`.
- `TranslateJob` returns early — before any `DeepLClient` is constructed — when the flag is set and the record already has a target-language translation.
- nl/en/de lang strings for the new option; the now-misleading "Overwrite all translations" modal heading neutralised to "Translate with DeepL".
- Pest coverage: the skip guard (no event, translation untouched, never reaches DeepL) and per-record batch dispatch.

## Test path
- [ ] Open the DeepL bulk action on a Filament resource list: the modal heading reads "Translate with DeepL" and shows an "Only translate untranslated records" checkbox, checked by default.
- [ ] With the checkbox **ON**, run the action against records that already have a target-language translation → those records keep their existing translation (no overwrite) and no success notification/`RecordLanguageUpdatedEvent` fires for them.
- [ ] With the checkbox **ON**, records whose target language is empty get translated as normal.
- [ ] **Uncheck** the checkbox and run the action → all selected records are (re)translated, overwriting existing target-language values (original behaviour).
- [ ] `vendor/bin/pest` passes (includes `tests/Feature/OnlyUntranslatedTest.php`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
